### PR TITLE
PHP 7系のサポートを修正

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		"issues": "https://github.com/g737a6b/php-r2-template/issues"
 	},
 	"require": {
-		"php": ">=8.0"
+		"php": ">=7.1"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^9.5"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "86e670deb279c4cea3d0f118a06ce5c7",
+    "content-hash": "86ebd24c85d69e74354299d427c9564d",
     "packages": [],
     "packages-dev": [
         {
@@ -607,16 +607,16 @@
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.5",
+            "version": "3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8"
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/aa4be8575f26070b100fccb67faabb28f21f66f8",
-                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
                 "shasum": ""
             },
             "require": {
@@ -655,7 +655,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.5"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
             },
             "funding": [
                 {
@@ -663,7 +663,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:57:25+00:00"
+            "time": "2021-12-02T12:48:52+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -2106,7 +2106,9 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": ">=7.1"
+    },
     "platform-dev": [],
     "plugin-api-version": "2.0.0"
 }

--- a/src/R2Template.php
+++ b/src/R2Template.php
@@ -21,9 +21,16 @@ class R2Template{
 	protected $file = "";
 
 	/**
+	 * @var string
+	 */
+	protected $path;
+
+	/**
 	 * @param string $path (optional)
 	 */
-	public function __construct(protected string $path = ""){}
+	public function __construct(string $path = ""){
+		$this->path = $path;
+	}
 
 	/**
 	 * @param string $path


### PR DESCRIPTION
- [x] `$ docker run -it --rm -v $(pwd):/app php:7.1-alpine /app/vendor/bin/phpunit /app/tests/`
- [x] `$ docker run -it --rm -v $(pwd):/app php:7.2-alpine /app/vendor/bin/phpunit /app/tests/`
- [x] `$ docker run -it --rm -v $(pwd):/app php:7.3-alpine /app/vendor/bin/phpunit /app/tests/`
- [x] `$ docker run -it --rm -v $(pwd):/app php:7.4-alpine /app/vendor/bin/phpunit /app/tests/`
- [x] `$ docker run -it --rm -v $(pwd):/app php:8.0-alpine /app/vendor/bin/phpunit /app/tests/`
- [x] `$ docker run -it --rm -v $(pwd):/app php:8.1-alpine /app/vendor/bin/phpunit /app/tests/`